### PR TITLE
Use string constants for custom properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@apeleghq/http-media-type-negotiator",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@apeleghq/http-media-type-negotiator",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "ISC",
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@apeleghq/http-media-type-negotiator",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "RFC‑aware HTTP media type negotiator - parses and normalises Accept headers and media types (RFC 9110), supports q-value ranking, wildcard matching, and a permissive mode for real‑world headers.",
 	"type": "module",
 	"main": "dist/index.cjs",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,3 +25,18 @@ export const TOKEN =
  * @see https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3
  */
 export const OWS = ' \t' as const;
+
+/**
+ * @internal
+ */
+export const $type = 'type' as const;
+
+/**
+ * @internal
+ */
+export const $subtype = 'subtype' as const;
+
+/**
+ * @internal
+ */
+export const $orignal = 'original' as const;

--- a/src/negotiateMediaTypeFactory.ts
+++ b/src/negotiateMediaTypeFactory.ts
@@ -13,6 +13,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
+import { $subtype, $type } from './constants.js';
 import normaliseMediaType from './normaliseMediaType.js';
 import parseAcceptHeader from './parseAcceptHeader.js';
 import parseMediaType, { type TMediaType } from './parseMediaType.js';
@@ -176,14 +177,14 @@ const negotiateMediaTypeFactory = (availableMediaTypes: string[]) => {
 						map.set(acceptableMediaType, availableMediaType);
 						return true;
 					} else if (
-						acceptableMediaType.subtype === '*' &&
-						acceptableMediaType.type === availableMediaType.type
+						acceptableMediaType[$subtype] === '*' &&
+						acceptableMediaType[$type] === availableMediaType[$type]
 					) {
 						map.set(acceptableMediaType, availableMediaType);
 						return true;
 					} else if (
-						acceptableMediaType.type === '*' &&
-						acceptableMediaType.subtype === '*'
+						acceptableMediaType[$type] === '*' &&
+						acceptableMediaType[$subtype] === '*'
 					) {
 						map.set(acceptableMediaType, availableMediaType);
 						return true;
@@ -209,13 +210,13 @@ const negotiateMediaTypeFactory = (availableMediaTypes: string[]) => {
 
 		// Now, find the type with the highest specificity
 		overlappingTypes.sort((a, b) => {
-			if (a.type === '*' && b.type !== '*') {
+			if (a[$type] === '*' && b[$type] !== '*') {
 				return 1;
-			} else if (a.type !== '*' && b.type === '*') {
+			} else if (a[$type] !== '*' && b[$type] === '*') {
 				return -1;
-			} else if (a.subtype === '*' && b.subtype !== '*') {
+			} else if (a[$subtype] === '*' && b[$subtype] !== '*') {
 				return 1;
-			} else if (a.subtype !== '*' && b.subtype === '*') {
+			} else if (a[$subtype] !== '*' && b[$subtype] === '*') {
 				return -1;
 			}
 

--- a/src/normaliseMediaType.ts
+++ b/src/normaliseMediaType.ts
@@ -13,9 +13,10 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
+import { $orignal, $subtype, $type } from './constants.js';
 import { type TMediaType } from './parseMediaType.js';
 
-type TNormalisedMediaType = TMediaType & { readonly original: TMediaType };
+type TNormalisedMediaType = TMediaType & { readonly [$orignal]: TMediaType };
 
 /**
  * Normalises a parsed media type into a canonical, case-normalised form and
@@ -68,19 +69,19 @@ const normaliseMediaType = (mediaType: TMediaType): TNormalisedMediaType => {
 		normalised,
 		Object.fromEntries([
 			[
-				'type',
+				$type,
 				{
-					get: () => mediaType.type.toLowerCase(),
+					get: () => mediaType[$type].toLowerCase(),
 				},
 			],
 			[
-				'subtype',
+				$subtype,
 				{
-					get: () => mediaType.subtype.toLowerCase(),
+					get: () => mediaType[$subtype].toLowerCase(),
 				},
 			],
 			[
-				'original',
+				$orignal,
 				{
 					get: () => mediaType,
 				},
@@ -91,5 +92,5 @@ const normaliseMediaType = (mediaType: TMediaType): TNormalisedMediaType => {
 	return normalised;
 };
 
-export type { TNormalisedMediaType, TMediaType };
+export type { TMediaType, TNormalisedMediaType };
 export default normaliseMediaType;

--- a/src/parseMediaType.ts
+++ b/src/parseMediaType.ts
@@ -13,6 +13,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
+import { $subtype, $type } from './constants.js';
 import { isOWS, isToken } from './utils.js';
 
 const STATE_INVALID = -1 as const;
@@ -43,8 +44,8 @@ type TState =
 	| typeof STATE_PARAMETER_QUOTED;
 
 type TMediaType = [mimeType: string, [parameter: string, value: string][]] & {
-	readonly type: string;
-	readonly subtype: string;
+	readonly [$type]: string;
+	readonly [$subtype]: string;
 };
 
 /**
@@ -260,13 +261,13 @@ const parseMediaType = (
 		result,
 		Object.fromEntries([
 			[
-				'type',
+				$type,
 				{
 					get: () => type,
 				},
 			],
 			[
-				'subtype',
+				$subtype,
 				{
 					get: () => subtype,
 				},


### PR DESCRIPTION
This reduces potential breakage when using tools such as the Closure compiler.