### PR TITLE
Support custom negotiation strategies

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
       contents: read
       id-token: write
     environment: CI

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,6 @@
 name: Run tests before merging
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@apeleghq/http-media-type-negotiator",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@apeleghq/http-media-type-negotiator",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "ISC",
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@apeleghq/http-media-type-negotiator",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "RFC-aware HTTP media type negotiator - parses and normalises Accept headers and media types (RFC 9110), supports q-value ranking, wildcard matching, and a permissive mode for real-world headers.",
 	"type": "module",
 	"main": "dist/index.cjs",

--- a/src/defaultStrategy.ts
+++ b/src/defaultStrategy.ts
@@ -1,0 +1,178 @@
+/* Copyright © 2025 Apeleg Limited. All rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+import { $subtype, $type } from './constants.js';
+import type { IMediaTypeNegotiationStrategy } from './negotiateMediaTypeFactory.js';
+import type { TMediaType } from './parseMediaType.js';
+import { wm } from './utils.js';
+
+/**
+ * Find parameters that overlap between two media types, excluding the `q`
+ * parameter.
+ *
+ * @internal
+ * @param a - Candidate media type (typically from `Accept` header).
+ * @param b - Available media type (server-provided).
+ * @returns Array of matching `[name, value]` parameter pairs.
+ */
+const findOverlappingParams = (a: TMediaType, b: TMediaType) => {
+	return a[1].filter((aparam) => {
+		return (
+			aparam[0] !== 'q' &&
+			b[1].some((bparam) => {
+				return aparam[0] === bparam[0] && aparam[1] === bparam[1];
+			})
+		);
+	});
+};
+
+/**
+ * Implements the default HTTP content negotiation strategy, ranking candidates
+ * according to the rules outlined in RFC 7231 §5.3.2.
+ *
+ * This function takes pre-parsed and pre-sorted lists of available (server) and
+ * acceptable (client) media types and finds the single best match from the
+ * available list. The selection process follows a strict, multi-stage ranking
+ * algorithm:
+ *
+ * 1.  **Filtering:** It first identifies all potential matches by comparing
+ *     each acceptable media range against all available types. A match can be
+ *     an exact type/subtype match, a subtype wildcard match (e.g., `text/*`)
+ *     or a full wildcard match (`*` + `/*`).
+ * 2.  **Quality Value (`q`):** It retains only the candidates that match the
+ *     highest q-value present among all potential matches. All others are
+ *     discarded.
+ * 3.  **Specificity Tie-Breaking:** If multiple candidates remain, they are
+ *     ranked by specificity in the following order of preference:
+ *       a. Full type/subtype (e.g., `application/json`) is preferred over
+ *          wildcard subtypes.
+ *       b. A wildcard subtype (e.g., `text/*`) is preferred over the full
+ *          wildcard (`*` + `/*`).
+ *       c. The number of matching non-q parameters. A media range with more
+ *          matching parameters to an available type is preferred.
+ *       d. Server preference. As a final tie-breaker, the original order of the
+ *          `availableMediaTypes` array is used, preferring the one that
+ *          appeared earliest.
+ *
+ * @internal
+ * @param availableMediaTypes - A readonly array of pre-parsed and normalised
+ *   media types supported by the server, in order of server preference.
+ * @param acceptableMediaTypes - A readonly array of pre-parsed media types
+ *   from the client's `Accept` header, pre-sorted by q-value in descending
+ *   order.
+ * @param qMap - A map that holds the q-value (weight) for each acceptable
+ *   media type, used for efficient lookups.
+ * @returns The best-matching normalised media type from the
+ *   `parsedAvailableTypes` array, or `null` if no suitable match is found.
+ */
+const defaultStrategy = ((availableMediaTypes, acceptableMediaTypes, qMap) => {
+	const map = wm<
+		(typeof acceptableMediaTypes)[number],
+		(typeof availableMediaTypes)[number]
+	>();
+
+	// First pass: remove media types that aren't possible
+	const overlappingTypes = acceptableMediaTypes.filter(
+		(acceptableMediaType) => {
+			const possible: (typeof availableMediaTypes)[number][] = [];
+			availableMediaTypes.forEach((availableMediaType) => {
+				if (acceptableMediaType[0] === availableMediaType[0]) {
+					possible.push(availableMediaType);
+				} else if (
+					acceptableMediaType[$subtype] === '*' &&
+					acceptableMediaType[$type] === availableMediaType[$type]
+				) {
+					possible.push(availableMediaType);
+				} else if (
+					acceptableMediaType[$type] === '*' &&
+					acceptableMediaType[$subtype] === '*'
+				) {
+					possible.push(availableMediaType);
+				}
+			});
+
+			possible.sort((a, b) => {
+				const overlappingA = findOverlappingParams(
+					acceptableMediaType,
+					a,
+				).length;
+				const overlappingB = findOverlappingParams(
+					acceptableMediaType,
+					b,
+				).length;
+
+				return overlappingB - overlappingA;
+			});
+
+			if (possible.length) {
+				map.set(acceptableMediaType, possible[0]);
+				return true;
+			}
+
+			return false;
+		},
+	);
+
+	if (overlappingTypes.length === 0) {
+		return null;
+	}
+
+	// Second pass: keep highest preference only
+	const highestQ = qMap.get(overlappingTypes[0])!;
+	for (let i = 1; i < overlappingTypes.length; i++) {
+		const q = qMap.get(overlappingTypes[i])!;
+		if (q !== highestQ) {
+			overlappingTypes.splice(i);
+			break;
+		}
+	}
+
+	// Now, find the type with the highest specificity
+	overlappingTypes.sort((a, b) => {
+		if (a[$type] === '*' && b[$type] !== '*') {
+			return 1;
+		} else if (a[$type] !== '*' && b[$type] === '*') {
+			return -1;
+		} else if (a[$subtype] === '*' && b[$subtype] !== '*') {
+			return 1;
+		} else if (a[$subtype] !== '*' && b[$subtype] === '*') {
+			return -1;
+		}
+
+		const availableA = map.get(a)!;
+		const availableB = map.get(b)!;
+
+		const overlappingA = findOverlappingParams(a, availableA).length;
+		const overlappingB = findOverlappingParams(b, availableB).length;
+
+		const result = overlappingB - overlappingA;
+		if (result !== 0) {
+			return result;
+		}
+
+		// If everything is equal, prefer server order
+		return (
+			availableMediaTypes.indexOf(availableA) -
+			availableMediaTypes.indexOf(availableB)
+		);
+	});
+
+	const highestRanked = overlappingTypes[0];
+	const availableType = map.get(highestRanked)!;
+
+	return availableType;
+}) satisfies IMediaTypeNegotiationStrategy;
+
+export default defaultStrategy;

--- a/src/negotiateMediaTypeFactory.ts
+++ b/src/negotiateMediaTypeFactory.ts
@@ -13,32 +13,51 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-import { $subtype, $type } from './constants.js';
+import defaultStrategy from './defaultStrategy.js';
 import findQ from './lib/findQ.js';
+import type { TNormalisedMediaType } from './normaliseMediaType.js';
 import normaliseMediaType from './normaliseMediaType.js';
-import rawParseAcceptHeader from './rawParseAcceptHeader.js';
 import parseMediaType, { type TMediaType } from './parseMediaType.js';
+import rawParseAcceptHeader from './rawParseAcceptHeader.js';
 import { wm } from './utils.js';
 
 /**
- * Find parameters that overlap between two media types, excluding the `q`
- * parameter.
+ * Defines the contract for a function that implements a content negotiation
+ * strategy.
  *
- * @internal
- * @param a - Candidate media type (typically from `Accept` header).
- * @param b - Available media type (server-provided).
- * @returns Array of matching `[name, value]` parameter pairs.
+ * A strategy function is responsible for selecting the single best media type
+ * from a list of available server types, based on a list of acceptable client
+ * types. It encapsulates the core ranking and selection logic.
+ *
+ * The factory function `negotiateMediaTypeFactory` handles the initial parsing
+ * of raw header strings and pre-sorts the acceptable types by their q-value.
+ * The strategy function receives this structured, pre-processed data and must
+ * implement the algorithm to find the single best match.
+ *
+ * This allows for custom negotiation logic beyond the default RFC 7231
+ * implementation, such as simpler matching rules or different tie-breaking
+ * behaviours.
+ *
+ * @param parsedAvailableTypes - A readonly array of pre-parsed and normalised
+ *   media types supported by the server, ordered by server preference (most
+ *   preferred first).
+ * @param parsedAcceptableTypes - A readonly array of pre-parsed media types
+ *   from the client's `Accept` header. This array is guaranteed to be
+ *   pre-sorted in descending order of q-value.
+ * @param qMap - A readonly map providing an efficient way to look up the
+ *   q-value (weight) for any given media type from the `parsedAcceptableTypes`
+ *   array.
+ * @returns The best-matching normalised media type from the
+ *   `parsedAvailableTypes` array, or `null` if no suitable match is found
+ *   according to the strategy's rules.
  */
-const findOverlappingParams = (a: TMediaType, b: TMediaType) => {
-	return a[1].filter((aparam) => {
-		return (
-			aparam[0] !== 'q' &&
-			b[1].some((bparam) => {
-				return aparam[0] === bparam[0] && aparam[1] === bparam[1];
-			})
-		);
-	});
-};
+interface IMediaTypeNegotiationStrategy {
+	(
+		parsedAvailableTypes: readonly TNormalisedMediaType[],
+		parsedAcceptableTypes: readonly TNormalisedMediaType[],
+		qMap: Readonly<WeakMap<TMediaType, number>>,
+	): TNormalisedMediaType | null;
+}
 
 /**
  * Create a media type negotiator for a fixed list of available media types.
@@ -71,6 +90,7 @@ const findOverlappingParams = (a: TMediaType, b: TMediaType) => {
  * @param availableMediaTypes - Array of server-supported media type header
  *   strings, from most preferred to least preferred.
  *   The original strings are preserved and returned on a match.
+ * @param strategy - Optional custom negotiation strategy.
  * @returns A function that, given an `Accept` header string and optional
  * `permissive` flag, returns the best matching available media type string, or
  * `null` if no match exists. If `accept` is falsy, the first available media
@@ -87,7 +107,10 @@ const findOverlappingParams = (a: TMediaType, b: TMediaType) => {
  *   'text/*;q=0.9, application/json;q=0.8'
  * ); // -> 'text/plain; charset=utf-8'
  */
-const negotiateMediaTypeFactory = (availableMediaTypes: string[]) => {
+const negotiateMediaTypeFactory = (
+	availableMediaTypes: string[],
+	strategy: IMediaTypeNegotiationStrategy = defaultStrategy,
+) => {
 	if (availableMediaTypes.length === 0) {
 		return () => null;
 	}
@@ -118,92 +141,26 @@ const negotiateMediaTypeFactory = (availableMediaTypes: string[]) => {
 			})
 			.filter(
 				Boolean as unknown as (
-					x: TMediaType | undefined,
-				) => x is TMediaType,
+					x: TNormalisedMediaType | undefined,
+				) => x is TNormalisedMediaType,
 			)
 			.sort((a, b) => {
 				const qa = qMap.get(a!)!;
 				const qb = qMap.get(b!)!;
 
 				return qb - qa;
-			}) as TMediaType[];
+			});
 
-		const map = wm<TMediaType, (typeof parsedAvailableTypes)[number]>();
-
-		// First pass: remove media types that aren't possible
-		const overlappingTypes = parsedAcceptableTypes.filter(
-			(acceptableMediaType) => {
-				return parsedAvailableTypes.some((availableMediaType) => {
-					if (acceptableMediaType[0] === availableMediaType[0]) {
-						map.set(acceptableMediaType, availableMediaType);
-						return true;
-					} else if (
-						acceptableMediaType[$subtype] === '*' &&
-						acceptableMediaType[$type] === availableMediaType[$type]
-					) {
-						map.set(acceptableMediaType, availableMediaType);
-						return true;
-					} else if (
-						acceptableMediaType[$type] === '*' &&
-						acceptableMediaType[$subtype] === '*'
-					) {
-						map.set(acceptableMediaType, availableMediaType);
-						return true;
-					}
-					return false;
-				});
-			},
+		const availableType = strategy(
+			parsedAvailableTypes,
+			parsedAcceptableTypes,
+			qMap,
 		);
+		const result = availableType ? mapToOriginal.get(availableType) : null;
 
-		if (overlappingTypes.length === 0) {
-			return null;
-		}
-
-		// Second pass: keep highest preference only
-		const highestQ = qMap.get(overlappingTypes[0])!;
-		for (let i = 1; i < overlappingTypes.length; i++) {
-			const q = qMap.get(overlappingTypes[i])!;
-			if (q !== highestQ) {
-				overlappingTypes.splice(i);
-				break;
-			}
-		}
-
-		// Now, find the type with the highest specificity
-		overlappingTypes.sort((a, b) => {
-			if (a[$type] === '*' && b[$type] !== '*') {
-				return 1;
-			} else if (a[$type] !== '*' && b[$type] === '*') {
-				return -1;
-			} else if (a[$subtype] === '*' && b[$subtype] !== '*') {
-				return 1;
-			} else if (a[$subtype] !== '*' && b[$subtype] === '*') {
-				return -1;
-			}
-
-			const availableA = map.get(a)!;
-			const availableB = map.get(b)!;
-
-			const overlappingA = findOverlappingParams(a, availableA).length;
-			const overlappingB = findOverlappingParams(b, availableB).length;
-
-			const result = overlappingB - overlappingA;
-			if (result !== 0) {
-				return result;
-			}
-
-			// If everything is equal, prefer server order
-			return (
-				parsedAvailableTypes.indexOf(availableA) -
-				parsedAvailableTypes.indexOf(availableB)
-			);
-		});
-
-		const highestRanked = overlappingTypes[0];
-		const availableType = map.get(highestRanked)!;
-
-		return mapToOriginal.get(availableType)!;
+		return result || null;
 	};
 };
 
 export default negotiateMediaTypeFactory;
+export type { IMediaTypeNegotiationStrategy };

--- a/test/defaultStrategy.test.ts
+++ b/test/defaultStrategy.test.ts
@@ -1,0 +1,250 @@
+/* Copyright © 2025 Apeleg Limited. All rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { $orignal, $subtype, $type } from '../src/constants.js';
+import defaultStrategy from '../src/defaultStrategy.js';
+import type { TNormalisedMediaType } from '../src/normaliseMediaType.js';
+import type { TMediaType } from '../src/parseMediaType.js';
+
+// Minimal mock of parseMediaType, sufficient for testing.
+const parseMediaType = (mediaTypeStr: string): TMediaType => {
+	const [full, ...paramsStr] = mediaTypeStr.split(';').map((s) => s.trim());
+	const [type, subtype] = full.split('/');
+	const params = paramsStr.map((p): [string, string] => {
+		const [name, ...val] = p.split('=');
+		return [name, val.join('=') || ''];
+	});
+
+	const result = [full, params] as TMediaType;
+	Object.defineProperty(result, $type, { value: type });
+	Object.defineProperty(result, $subtype, { value: subtype });
+
+	return result;
+};
+
+// Minimal mock of normaliseMediaType.
+const normaliseMediaType = (parsed: TMediaType): TNormalisedMediaType => {
+	const [full, params] = parsed;
+	const [type, subtype] = full.split('/');
+	const newFull = `${type.toLowerCase()}/${subtype.toLowerCase()}`;
+	const newParams = params
+		.map(([name, value]) => [name.toLowerCase(), value])
+		.sort(([a], [b]) => a.localeCompare(b));
+
+	const result = [newFull, newParams] as TNormalisedMediaType;
+	Object.defineProperty(result, $type, { value: type.toLowerCase() });
+	Object.defineProperty(result, $subtype, { value: subtype.toLowerCase() });
+	Object.defineProperty(result, $orignal, { value: parsed });
+
+	return result;
+};
+
+// Minimal mock of findQ.
+const findQ = (parsed: TMediaType) => {
+	const qParam = parsed[1].find((p) => p[0].toLowerCase() === 'q');
+	if (!qParam || qParam[1] === '') return 1;
+	const q = parseFloat(qParam[1]);
+	return isNaN(q) ? 1 : q;
+};
+
+// --- Helper Function for Test Scenarios ---
+
+/**
+ * Prepares the necessary data structures for calling `defaultStrategy`.
+ * This mimics the setup performed by `negotiateMediaTypeFactory`.
+ */
+const setup = (availableMediaTypes: string[], acceptHeader: string) => {
+	const parsedAvailableTypes = availableMediaTypes.map((type) =>
+		normaliseMediaType(parseMediaType(type)),
+	);
+	const mapToOriginal = new Map(
+		parsedAvailableTypes.map((parsed, i) => [
+			parsed,
+			availableMediaTypes[i],
+		]),
+	);
+
+	const qMap = new WeakMap<TMediaType, number>();
+	const parsedAcceptableTypes = acceptHeader
+		.split(',')
+		.map((t) => t.trim())
+		.filter(Boolean)
+		.map((type) => {
+			const parsed = parseMediaType(type);
+			const normalised = normaliseMediaType(parsed);
+			const q = findQ(normalised);
+			if (q === 0) return undefined;
+			qMap.set(normalised, q);
+			return normalised;
+		})
+		.filter(Boolean as unknown as (x: unknown) => x is TNormalisedMediaType)
+		.sort((a, b) => qMap.get(b)! - qMap.get(a)!);
+
+	return { parsedAvailableTypes, parsedAcceptableTypes, qMap, mapToOriginal };
+};
+
+const runStrategy = (available: string[], accept: string) => {
+	const { parsedAvailableTypes, parsedAcceptableTypes, qMap, mapToOriginal } =
+		setup(available, accept);
+	const result = defaultStrategy(
+		parsedAvailableTypes,
+		parsedAcceptableTypes,
+		qMap,
+	);
+	return result ? mapToOriginal.get(result) : null;
+};
+
+describe('defaultStrategy', () => {
+	it('should return null if no server types are available', () => {
+		const result = runStrategy([], 'application/json');
+		assert.equal(result, null);
+	});
+
+	it('should return null if no overlap exists', () => {
+		const result = runStrategy(['image/png'], 'application/json');
+		assert.equal(result, null);
+	});
+
+	it('should return the server-preferred type for a full wildcard `*/*`', () => {
+		const available = ['text/html', 'application/json'];
+		const result = runStrategy(available, '*/*');
+		assert.equal(result, 'text/html');
+	});
+
+	it('should perform an exact match', () => {
+		const available = ['text/html', 'application/json'];
+		const result = runStrategy(available, 'application/json');
+		assert.equal(result, 'application/json');
+	});
+
+	it('should ignore client types with q=0', () => {
+		const available = ['text/html', 'application/json'];
+		const result = runStrategy(
+			available,
+			'application/json;q=0, text/html;q=0.8',
+		);
+		assert.equal(result, 'text/html');
+	});
+
+	describe('Ranking & Tie-Breaking', () => {
+		it('should select the type with the highest q-value', () => {
+			const available = ['text/plain', 'text/html'];
+			const accept = 'text/plain;q=0.5, text/html;q=0.9';
+			const result = runStrategy(available, accept);
+			assert.equal(result, 'text/html');
+		});
+
+		it('Tie-Breaker 1: should prefer a specific type over a wildcard subtype', () => {
+			const available = ['text/plain', 'application/json'];
+			const accept = 'text/*, application/json'; // equal q=1
+			const result = runStrategy(available, accept);
+			// `application/json` is a more specific match than `text/*` for `text/plain`.
+			assert.equal(result, 'application/json');
+		});
+
+		it('Tie-Breaker 2: should prefer a wildcard subtype over a full wildcard', () => {
+			const available = ['image/png', 'application/json'];
+			const accept = '*/*, image/*'; // equal q=1
+			const result = runStrategy(available, accept);
+			// `image/*` is more specific than `*/*`.
+			assert.equal(result, 'image/png');
+		});
+
+		it('Tie-Breaker 3: should prefer the type with more matching parameters', () => {
+			const available = [
+				'text/html;profile=a',
+				'text/html;charset=utf-8;profile=b',
+			];
+
+			const acceptMap = [
+				// Both match `text/html;profile=b`, but the second available
+				// type has more matching params.
+				['text/html;profile=b', available[1]],
+				// Both match `text/html;profile=a`, but the first available
+				// type has more matching params.
+				['text/html;profile=a', available[0]],
+				// Both match both `text/html;profile=a` and
+				// `text/html;profile=b`, but the first available is preferred
+				// by the server.
+				['text/html;profile=b,text/html;profile=a', available[0]],
+				// Both match both `text/html;profile=a` and
+				// `text/html;profile=b`, but the second available is preferred
+				// by the client.
+				[
+					'text/html;profile=b,text/html;profile=a;q=0.99',
+					available[1],
+				],
+				// Both match both `text/html;profile=a` and
+				// `text/html;profile=b`, but the second available is preferred
+				// by the client (same as previous but testing q evaluation).
+				[
+					'text/html;profile=a;q=0.99,text/html;profile=b',
+					available[1],
+				],
+			];
+			acceptMap.forEach(([accept, expected]) => {
+				const result = runStrategy(available, accept);
+				assert.equal(result, expected);
+			});
+		});
+
+		it('Tie-Breaker 4: should use server preference as the final tie-breaker', () => {
+			const available = ['audio/basic', 'audio/aiff']; // Server prefers basic
+			const accept = 'audio/*';
+			const result = runStrategy(available, accept);
+			// Both are equally specific, q=1, no params. Server preference wins.
+			assert.equal(result, 'audio/basic');
+		});
+	});
+
+	describe('Complex Scenarios', () => {
+		it('should correctly navigate a complex Accept header', () => {
+			const available = [
+				'image/svg+xml',
+				'application/json',
+				'text/html;charset=utf-8',
+			];
+			const accept =
+				'text/html;q=0.8, application/xhtml+xml, application/xml;q=0.9, image/*;q=0.7, */*;q=0.5';
+
+			// Analysis:
+			// - `application/xhtml+xml` (q=1) has no match.
+			// - `application/xml` (q=0.9) has no match.
+			// - `text/html` (q=0.8) matches `text/html;charset=utf-8`.
+			// - `image/*` (q=0.7) matches `image/svg+xml`.
+			// The highest q-value with a match is 0.8.
+			const result = runStrategy(available, accept);
+			assert.equal(result, 'text/html;charset=utf-8');
+		});
+
+		it('should prefer specific match even if wildcard appears first in header', () => {
+			const available = ['text/plain', 'text/html'];
+			const accept = 'text/*, text/html'; // Both q=1
+			// `text/html` is a more specific match for itself than `text/*`.
+			const result = runStrategy(available, accept);
+			assert.equal(result, 'text/html');
+		});
+
+		it('should handle case-insensitivity in type, subtype, and param names', () => {
+			const available = ['application/json;charset=UTF-8'];
+			const accept = 'APPLICATION/JSON;CHARSET=UTF-8';
+			const result = runStrategy(available, accept);
+			assert.equal(result, 'application/json;charset=UTF-8');
+		});
+	});
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -16,6 +16,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../@types/importmeta.d.ts" />
 
+import './defaultStrategy.test.js';
 import './negotiateMediaType.test.js';
 import './parseMediaType.test.js';
 import './rawParseAcceptHeader.test.js';


### PR DESCRIPTION
Refactors the core negotiation algorithm out of `negotiateMediaTypeFactory` and into a new, swappable `defaultStrategy`.

The factory now accepts an optional `strategy` function, allowing consumers to provide custom logic for media type selection.

This change also resolves a minor bug in the tie-breaking logic where the best available type was not always chosen for a given `Accept` media range, particularly when parameter matching was the deciding factor.

- Adds `IMediaTypeNegotiationStrategy` interface for custom implementations.
- Includes dedicated unit tests for `defaultStrategy`.
- Updates CI permissions.